### PR TITLE
BLD: Implement Duncan's suggestion and add gwtc_test to entry points

### DIFF
--- a/recipes/gwtc-tools/meta.yaml
+++ b/recipes/gwtc-tools/meta.yaml
@@ -15,6 +15,7 @@ build:
     - gwtc_diff = gwtc:gwtc_diff
     - gwtc_get_gevent_coinc_files = gwtc:gwtc_get_gevent_coinc_files
     - gwtc_create_from_query = gwtc:gwtc_create_from_query
+    - gwtc_test = gwtc:gwtc_test
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   number: 0


### PR DESCRIPTION
Implementing Duncan's suggestion that the entry points in `meta.yaml` don't match those of the `pyproject.toml`, and this could be responsible for the failure of the pipeline.